### PR TITLE
Add weights to the confusion_matrix & fix filtering dataframe row numbering

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -18,6 +18,7 @@ parser.add_option('-w', '--weightFeature',  action='store', type=str, dest='weig
 parser.add_option('-t', '--TreeName',  action='store', type=str, dest='treename',  default='Tree', help='Name of TTree name inside root files')
 parser.add_option('--PlotROC',  action="store_true", dest='plot_ROC',  help='Flag to determine if one should plot ROC')
 parser.add_option('--PlotObsROC',  action="store_true", dest='plot_obs_ROC',  help='Flag to determine if one should plot observable ROCs')
+parser.add_option('--PlotResampleRatio',  action="store_true", dest='plot_resampledRatio',  help='Flag to determine if one should plot a ratio of resampled vs original distribution')
 parser.add_option('-m', '--model', action='store', type=str, dest='model', default=None, help='path to the model.')
 parser.add_option('--scale-method', action='store', dest='scale_method', type=str, default=None, help='scaling method for input data. e.g minmax, standard.')
 (opts, args) = parser.parse_args()
@@ -76,6 +77,7 @@ for i in evaluate:
                         plot_ROC=opts.plot_ROC,
                         plot_obs_ROC=opts.plot_obs_ROC,
                         scaling=scale_method,
+                        plot_resampledRatio=opts.plot_resampledRatio,
                     )
 # Evaluate performance
 print("<evaluate.py::__init__>::   Evaluate Performance of Model")

--- a/ml/utils/loading.py
+++ b/ml/utils/loading.py
@@ -269,6 +269,7 @@ class Loader():
         global_name="Test",
         plot_ROC = True,
         plot_obs_ROC = True,
+        plot_resampledRatio=False,
         ext_binning = None,
         ext_plot_path=None,
         verbose=False,
@@ -346,15 +347,15 @@ class Loader():
                 print("<loading.py::load_result>::   Column {}:  min  =  {},  max  =  {}".format(column,min,max))
                 print(binning[idx])       
 
-        # no point in plotting distributions with too few events, they only look bad 
-        #if int(nentries) > 5000: 
-        # plot ROC curves 
+        # no point in plotting distributions with too few events, they only look bad
+        #if int(nentries) > 5000:
+        # plot ROC curves
         print("<loading.py::load_result>::   Printing ROC")
         if plot_ROC:
             draw_ROC(X0, X1, W0, W1, weights, label, global_name, nentries, plot)
         if plot_obs_ROC:
-            draw_Obs_ROC(X0, X1, W0, W1, weights, label, global_name, nentries, plot)
-        
+            draw_Obs_ROC(X0, X1, W0, W1, weights, label, global_name, nentries, plot, plot_resampledRatio)
+
         if verbose:
             print("<loading.py::load_result>::   Printing weighted distributions")
         # plot reweighted distributions
@@ -399,7 +400,7 @@ class Loader():
         #var = 'QSFUP',
         #plot = False
         self,
-        y_true, 
+        y_true,
         p1_raw,
         p1_cal,
         label = None,


### PR DESCRIPTION
# Purpose

Take into account +1/-1 weights for the resampled data in the confusion_matrix calculation - based on fork merge https://github.com/sjiggins/carl-torch/pull/13. 

Update:
- Fix the number of resampled events ( -> sum of weights)
- Add an option to make the ratio plot of resampled/original distribution
- Post filtering the row numbers are reset to `0-N` events in order to allow flattening of ROOT TBranches to panda dataframe