### PR TITLE
Hot Fix for metaData local scope in loading class

### DIFF
--- a/ml/utils/loading.py
+++ b/ml/utils/loading.py
@@ -190,6 +190,7 @@ class Loader():
         x1 = x1[sorted(x1.columns)]
 
         # get metadata, i.e. max, min, mean, std of all the variables in the dataframes
+        metaData = defaultdict()
         if scaling == "standard":
             metaData = {v : {x0[v].mean(), x0[v].std() } for v in  x0.columns }
             logger.info("Storing Z0 Standard scaling metadata: {}".format(metaData))


### PR DESCRIPTION
# Purpose

Hot fix for local scoped metaData dictionary in `ml/utils/loading.py` due to update on scaling method.
