### PR TITLE
Minor Bug Fixes to data entry counting and metadata dictionary formation

### DIFF
--- a/ml/base.py
+++ b/ml/base.py
@@ -102,8 +102,6 @@ class Estimator(object):
             logger.debug("Saving input scaling information to %s_x_means.npy and %s_x_stds.npy", filename, filename)
             np.save(filename + "_x_means.npy", self.x_scaling_means)
             np.save(filename + "_x_stds.npy", self.x_scaling_stds)
-            np.save(filename + "_x_mins.npy", self.x_scaling_mins)
-            np.save(filename + "_x_maxs.npy", self.x_scaling_maxs)
 
         # Save state dict
         logger.debug("Saving state dictionary to %s_state_dict.pt", filename)

--- a/ml/base.py
+++ b/ml/base.py
@@ -105,6 +105,11 @@ class Estimator(object):
             np.save(filename + "_x_means.npy", self.x_scaling_means)
             np.save(filename + "_x_stds.npy", self.x_scaling_stds)
 
+        if self.x_scaling_mins is not None and self.x_scaling_maxs is not None:
+            logger.debug("Saving input scaling information to %s_x_mins.npy and %s_x_maxs.npy", filename, filename)
+            np.save(filename + "_x_mins.npy", self.x_scaling_mins)
+            np.save(filename + "_x_maxs.npy", self.x_scaling_maxs)
+
         # Save state dict
         logger.debug("Saving state dictionary to %s_state_dict.pt", filename)
         torch.save(self.model.state_dict(), filename + "_state_dict.pt")

--- a/ml/base.py
+++ b/ml/base.py
@@ -40,6 +40,8 @@ class Estimator(object):
         self.n_parameters = None
         self.x_scaling_means = None
         self.x_scaling_stds = None
+        self.x_scaling_mins = None
+        self.x_scaling_maxs = None
         self.scaling_method = None
         self.scaling_clamp = False
         self.clamp_min = None

--- a/ml/utils/loading.py
+++ b/ml/utils/loading.py
@@ -193,7 +193,7 @@ class Loader():
         #metaData = defaultdict()
         metaData = OrderedDict()
         if scaling == "standard":
-            metaData = {v : {x0[v].mean() , x0[v].std() } for v in  x0.columns }
+            metaData = {v : (x0[v].mean() , x0[v].std() ) for v in  x0.columns }
             logger.info("Storing Z0 Standard scaling metadata: {}".format(metaData))
         elif scaling == "minmax":
             #metaData = {v : OrderedDict({x0[v].min() if x0[v].min() < x1[v].min() else x1[v].min(), x0[v].max() if x0[v].max() > x1[v].max() else x1[v].max() } for v in  x0.columns) }

--- a/ml/utils/loading.py
+++ b/ml/utils/loading.py
@@ -45,7 +45,7 @@ class Loader():
         save = False,
         correlation = True,
         preprocessing = False,
-        nentries = 0,
+        nentries = -1,
         pathA = '',
         pathB = '',
         normalise = False,

--- a/ml/utils/tools.py
+++ b/ml/utils/tools.py
@@ -287,6 +287,10 @@ def load(
         logger.info("Attempting extract features however user did not define values. Using all keys inside TTree as features.")
         features = X_tree.keys()
 
+    # Ensure that we don't try to load 0 events. Convert 0 to None, meaning load the entire dataset
+    if n == 0:
+        n = None
+
     # Extract the pandas dataframe - warning about jagged arrays
     #df = X_tree.pandas.df(features, flatten=False)
     logger.info("<{}> Converting uproot array to panda's dataframe".format(process_time()))

--- a/ml/utils/tools.py
+++ b/ml/utils/tools.py
@@ -85,7 +85,7 @@ def HarmonisedLoading(
     fB="",
     features=[],
     weightFeature="DummyEvtWeight",
-    nentries=0,
+    nentries=-1,
     TreeName="Tree",
     Filter=None,
     do_self_dope=False,
@@ -238,7 +238,7 @@ def load(
     f="",
     features=[],
     weightFeature="DummyEvtWeight",
-    n=0,
+    n=-1,
     t="Tree",
     weight_polarity=False,
     Filter=None,
@@ -288,8 +288,8 @@ def load(
         features = X_tree.keys()
 
     # Ensure that we don't try to load 0 events. Convert 0 to None, meaning load the entire dataset
-    if n == 0:
-        n = None
+    #if n == 0:
+    #    n = None
 
     # Extract the pandas dataframe - warning about jagged arrays
     #df = X_tree.pandas.df(features, flatten=False)

--- a/ml/utils/tools.py
+++ b/ml/utils/tools.py
@@ -288,8 +288,8 @@ def load(
         features = X_tree.keys()
 
     # Ensure that we don't try to load 0 events. Convert 0 to None, meaning load the entire dataset
-    #if n == 0:
-    #    n = None
+    if n == 0:
+        n = None
 
     # Extract the pandas dataframe - warning about jagged arrays
     #df = X_tree.pandas.df(features, flatten=False)


### PR DESCRIPTION
# Purpose

Fix two key bugs inside `base.py` and `tools.py`:

- `base.py`: New defaults for `self.x_scaling_mins(maxs)` and adding unique logic statements for saving data to numpy arrays in case either Z0 or min/max scaling has None default value.
- `tools.py`: Check number of entries to be extracted by uproot `arrays()` method for `n==0` value. If so then set to None. This will result in loading all possible values from start to end of file.
- `loading.py`: Fixed metaData dictionary formation to use a tuple not a dictionary of dictionary