### PR TITLE
Dynamic CPU/GPU loading of array in output score regulated categorical cross-entropy loss function

### DIFF
--- a/ml/functions.py
+++ b/ml/functions.py
@@ -70,7 +70,7 @@ def _ratio_xe_prob_reg(s_hat, y_true, w):
 
     # Calculate the suppresion term - This is all static at present must change to allow user hyperparameter optimisation
     s_hat_temp = torch.sub(s_hat, 0.5)
-    s_hat_temp = torch.where(s_hat_temp > 0, s_hat_temp, torch.zeros(s_hat_temp.size()).to("cuda", torch.float, non_blocking=True))
+    s_hat_temp = torch.where(s_hat_temp > 0, s_hat_temp, torch.zeros(s_hat_temp.size()).to("cuda" if torch.cuda.is_available() else "cpu", torch.float, non_blocking=True))
     s_hat_temp = torch.mul(s_hat_temp, 2)
     s_hat_temp = torch.pow(s_hat_temp, 4)
     inverse_sub = torch.reciprocal(1-s_hat_temp)


### PR DESCRIPTION
# Purpose

The implement loss function `_ratio_xe_prob_reg()` in ml/functions.py which suppresses the output using an power law subtraction term based on the network output was loaded onto a gpu manually. I.e. hard coded load of a temporary numpy array using `torch.to_device()`. 

This has since been replaced by a dynamic call internal to determine if a GPU or CPU is to be used. 