### PR TITLE
Bug Fix:   Adding --scale-method default for evaluation steering

### DIFF
--- a/arg_handler.py
+++ b/arg_handler.py
@@ -58,7 +58,7 @@ def arg_handler_eval():
     parser.add_argument('-b', '--binning',  action='store', type=str, dest='binning',  default=None, help='path to binning yaml file')
     parser.add_argument('--normalise', action='store_true', dest='normalise', default=False, help='enforce normalization when plotting')
     parser.add_argument('--rawWeight',  action="store_true", dest='raw_weight',  help='Flag to use raw event weight')
-    parser.add_argument('--scale-method', action='store', dest='scale_method', type=str, default=None, help='scaling method for input data. e.g minmax, standard')
+    parser.add_argument('--scale-method', action='store', dest='scale_method', type=str, default='minmax', help='scaling method for input data. e.g minmax, standard')
     parser.add_argument('--weight-protection', action='store_true', dest='weight_protection',  default=False, help='implement CARL weight protection by clipping away (+-) inf values')
     parser.add_argument('--weight-threshold', action='store', dest='weight_threshold', type=percentile_range, default=100, help='implement CARL weight clipping by clipping based on user defined percentile. Valid range from [0,100]% with floating precision')
     opts = parser.parse_args()


### PR DESCRIPTION
# Purpose

The `--scale-method` in the argument handler of the evaluation steering file does not at present store a default argument. Therefore setting to `minmax` to ensure defined behaviour with evaluation. 