### PR TITLE
[WIP] Extend user-definable binning definitions + add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# python cache files
+*.pyc
+
+# temporary (.swp) files
+*.swp

--- a/arg_handler.py
+++ b/arg_handler.py
@@ -24,6 +24,7 @@ def arg_handler_train():
     parser.add_argument('-w', '--weightFeature',  action='store', type=str, dest='weightFeature',  default='DummyEvtWeight', help='Name of event weights feature in TTree')
     parser.add_argument('-t', '--TreeName',  action='store', type=str, dest='treename',  default='Tree', help='Name of TTree name inside root files')
     parser.add_argument('-b', '--binning',  action='store', type=str, dest='binning',  default=None, help='path to binning yaml file.')
+    parser.add_argument('-nb','--nbins',type=int,default=100,help='number of bins in evaluation plots') # RB
     parser.add_argument('-l', '--layers', action='store', type=int, dest='layers', nargs='*', default=None, help='number of nodes for each layer')
     parser.add_argument('-d', '--dropout-prob', action='store', type=float, dest='dropout_prob', default=None, help='Dropout probability for internal hidden layers')
     parser.add_argument('-r', '--regularise', action='store', type=str, dest='regularise', default=None, help='Regularisation technique for the loss function [L0, L1, L2]')

--- a/arg_handler.py
+++ b/arg_handler.py
@@ -62,6 +62,7 @@ def arg_handler_eval():
     parser.add_argument('--PlotResampleRatio',  action="store_true", dest='plot_resampledRatio',  help='Flag to determine if one should plot a ratio of resampled vs original distribution')
     parser.add_argument('-m', '--model', action='store', type=str, dest='model', default=None, help='path to the model')
     parser.add_argument('-b', '--binning',  action='store', type=str, dest='binning',  default=None, help='path to binning yaml file')
+    parser.add_argument('-nb','--nbins',type=int,default=100,help='number of bins in evaluation plots') # RB
     parser.add_argument('--normalise', action='store_true', dest='normalise', default=False, help='enforce normalization when plotting')
     parser.add_argument('--rawWeight',  action="store_true", dest='raw_weight',  help='Flag to use raw event weight')
     parser.add_argument('--scale-method', action='store', dest='scale_method', type=str, default='minmax', help='scaling method for input data. e.g minmax, standard')

--- a/evaluate.py
+++ b/evaluate.py
@@ -18,6 +18,7 @@ weightFeature = opts.weightFeature
 treename = opts.treename
 model = opts.model
 binning = opts.binning
+nbins = opts.nbins
 normalise = opts.normalise
 raw_weight = opts.raw_weight
 scale_method = opts.scale_method
@@ -79,6 +80,7 @@ for i in evaluate:
         plot_ROC=opts.plot_ROC,
         plot_obs_ROC=opts.plot_obs_ROC,
         ext_binning = binning,
+        nbins = nbins,
         normalise = normalise,
         scaling=scale_method,
         plot_resampledRatio=opts.plot_resampledRatio,

--- a/example_binning.yaml
+++ b/example_binning.yaml
@@ -1,0 +1,16 @@
+# of the sort (start,stop,step==binwidth)
+# run evaluate.py with the option --binning/-b example_binning.yaml
+# overrides
+binning : 
+  mJ : [50,800,10]
+  absdeltaPhiVJ : [1.5,3.3,0.1]
+  Colour : [0.0,10.0,0.1]
+  deltaRbTrkJbTrkJ : [0.0,1.4,0.05]
+  deltaYVJ : [0.0,2.8,0.05]
+  lepPtBalance : [0.0,1.0,0.05]
+  MET : [0.0,800.0,10]
+  pTL : [0.0,800.0,10]
+  pTV : [350.0,1200.,10]
+  pTBTrkJ1 : [0.0,300.0,5]
+  pTBTrkJ2 : [0.0,300.0,5]
+  pTBTrkJ3 : [0.0,300.0,5]

--- a/ml/utils/loading.py
+++ b/ml/utils/loading.py
@@ -470,6 +470,7 @@ class Loader():
         plot_ROC = True,
         plot_obs_ROC = True,
         plot_resampledRatio=False,
+        nbins=100,
         ext_binning = None,
         ext_plot_path=None,
         verbose=False,
@@ -517,7 +518,7 @@ class Loader():
             logger.info("Calculating min/max range for plots & binning")
         binning = defaultdict()
         minmax = defaultdict()
-        divisions = 100 # 50 default
+        divisions = nbins # 100 default
 
         # external binning from yaml file.
         if ext_binning:
@@ -541,16 +542,16 @@ class Loader():
             #  as integer values indicate well bounded data
             intTest = [ (i % 1) == 0  for i in X0[:,idx] ]
             intTest = all(intTest) #np.all(intTest == True)
-            upperThreshold = 100 if intTest or np.any(X0[:,idx] < 0) else 98
+            upperThreshold = 98 if not intTest else 100 
             max = np.percentile(X0[:,idx], upperThreshold)
-            lowerThreshold = 0 if (np.any(X0[:,idx] < 0 ) or intTest) else 0
+            lowerThreshold=0
             min = np.percentile(X0[:,idx], lowerThreshold)
             minmax[idx] = [min,max]
             binning[idx] = np.linspace(min, max, divisions)
             if verbose:
-                logger.info("<loading.py::load_result>::   Column {}:  min  =  {},  max  =  {}".format(column,min,max))
+                logger.info("<loading.py::load_result>::   Column {}:  min  =  {},  max  =  {}".format(key,min,max))
                 print(binning[idx])       
-
+        
         # no point in plotting distributions with too few events, they only look bad
         #if int(nentries) > 5000:
         # plot ROC curves

--- a/train.py
+++ b/train.py
@@ -27,6 +27,7 @@ features = opts.features.split(",")
 weightFeature = opts.weightFeature
 treename = opts.treename
 binning = opts.binning
+nbins = opts.nbins
 n_hidden = tuple(opts.layers) if opts.layers != None else tuple( repeat( (len(features)), 3) )
 batch_size = opts.batch_size
 per_epoch_plot = opts.per_epoch_plot
@@ -144,6 +145,7 @@ if per_epoch_plot:
         "nentries":n,
         "global_name":global_name,
         "ext_binning":binning,
+        "nbins":nbins,
         "verbose" : False,
         "plot_ROC" : False,
         "plot_obs_ROC" : False,
@@ -161,6 +163,7 @@ if per_epoch_plot:
         "nentries":n,
         "global_name":global_name,
         "ext_binning":binning,
+        "nbins":nbins,
         "verbose" : False,
         "plot_ROC" : False,
         "plot_obs_ROC" : False,


### PR DESCRIPTION
Default behavior of CARL evaluation script is to only plot data on the 98% percentile, except when data has integer values only OR when data has negative values. 

For variables with negative default values and with quite high ranges (e.g. Colour ring variables in boosted VHbb), the latter criterion doesn't allow plotting the bulk of the distribution. This MR fixes this. Also, it allows users to either define number of bins when plotting the 98% percentile data.

I also add an example of a yaml binning file, which bypasses these definitions.

Also, a gitignore file to ignore .pyc and .swp files.