### PR TITLE
Adding possibility to leave training code after making only input DS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# python cache files
+*.pyc

--- a/arg_handler.py
+++ b/arg_handler.py
@@ -43,6 +43,7 @@ def arg_handler_train():
     parser.add_argument('--n_workers', action='store', dest='n_workers', type=int, default=8, help='Number of batch workers (default: 8)')
     parser.add_argument('--clipFeatures',  action='store', type=str, dest='clipFeatures',  default='', help='Comma separated list of features to be clipped')
     parser.add_argument('--clippingQuantile', action='store', type=float, dest='clippingQuantile', default=None, help='The quantile at which the features will be clipped')
+    parser.add_argument('--makeInputDSOnly', action='store_true', dest='makeInputDSOnly', default=False, help='If we should only make the input .npy datasets.')
     opts = parser.parse_args()
     return opts
 

--- a/train.py
+++ b/train.py
@@ -114,6 +114,11 @@ else:
     logger.info(" Loaded new datasets ")
 #######################################
 
+# Make only the input dataset files
+if opts.makeInputDSOnly:
+    logger.info(" Exiting after making the datasets")
+    sys.exit(1)
+
 #######################################
 # Estimate the likelihood ratio using a NN model
 #   -> Calculate number of input variables as rudimentary guess


### PR DESCRIPTION
Sometimes we want to train with a dataset and evaluate the model on a different dataset, but for this, the .npy dataset (DS) needs to be created.

We added an additional flag to allow this.

Also ignoring pycache files.