### PR TITLE
Define early stopping exception

### DIFF
--- a/ml/trainers.py
+++ b/ml/trainers.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 class NanException(Exception):
     pass
 
-
+class EarlyStoppingException(Exception):
+    pass
 
 class NumpyDataset(Dataset):
     """ Dataset for numpy arrays with explicit memmap support """


### PR DESCRIPTION
The Early Stopping exception wasn't defined, so the code crashed after catching the exception. This adds the proper definition so early stopping can actually be used.